### PR TITLE
NT-11: Setup `certbot` and `NGINX` proxy server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+* @Steellemm @iamsaywhat @TorgashSad

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -110,3 +110,50 @@ We use a simple systemd daemon to run the application on the server, as a way to
     $ chown -R <username>:<username> /home/<username>/.ssh
     ```
 Now the private key can be used to gain access to the server as a <username> user.
+
+## Setup [NGINX](https://www.nginx.com/) proxy and [certbot](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) to enable HTTPS
+
+1. Login as root user to the server via ssh: 
+    ```
+    $ ssh root@<ip-address>
+    root@<ip-address>'s password:
+    ```
+2. Install [NGINX](https://www.nginx.com/) proxy server:
+    ```bash
+    $ sudo apt update
+    $ sudo apt install nginx
+    ```
+3. Install certbot
+    ```bash
+    $ sudo apt install snapd
+    $ sudo snap install --classic certbot
+    ```
+4. Get SSL certificates for your domain:
+    ```bash
+    $ sudo ln -s /snap/bin/certbot /usr/bin/certbot
+    $ sudo certbot certonly --nginx
+    ```
+5. Remove default NGINX configuration:
+    ```bash
+    $ rm -rf /etc/nginx/sites-enabled/*
+    $ rm -rf /etc/nginx/sites-available/*
+    ```
+6. Install NGINX configs to server:
+    ```bash
+    # from your machine
+    $ rsync -r ./deploy/nginx/* root@<ip-address>:/etc/nginx/sites-available/
+    ```
+7. Add configs to NGINX configuration:
+    ```bash
+    # on server
+    $ ln -s /etc/nginx/sites-available/default.conf /etc/nginx/sites-enabled/default.conf
+    $ ln -s /etc/nginx/sites-available/no-thanks.conf /etc/nginx/sites-enabled/no-thanks.conf
+    ```
+8. Generate SSL certificate for default server:
+    ```bash
+    $ openssl req -nodes -new -x509 -subj "/CN=localhost" -keyout /etc/nginx/ssl/default.key -out /etc/nginx/ssl/default.crt
+    ```
+9. Reload NGINX to apply new configuration:
+    ```bash
+    $ nginx -s reload
+    ```

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    listen 443 default_server ssl;
+    listen [::]:443 default_server ssl;
+    ssl_certificate /etc/nginx/ssl/default.crt;
+    ssl_certificate_key /etc/nginx/ssl/default.key;
+    return 444; # silently drop the connection
+}

--- a/deploy/nginx/no-thanks.conf
+++ b/deploy/nginx/no-thanks.conf
@@ -1,0 +1,37 @@
+upstream no-thanks {
+    server localhost:8080;
+}
+
+server {
+    server_name emur.space; # managed by Certbot
+
+    root /var/www/html;
+
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header Origin http://$proxy_host;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+
+        proxy_redirect off;
+        proxy_pass http://no-thanks;
+    }
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/emur.space/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/emur.space/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name emur.space; # managed by Certbot
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
📝 **Task:** [NT-11](https://trello.com/c/qycIL1eZ/27-nt-11-devops-setup-certbot-and-proxy-server)

# Description
In #6 we already deployed the application on the server, now we need to get SSL certificates for our domain and configure `NGINX` proxy server to provide `HTTPS` connection for users.

To do this, we needed to take the following steps:
- Install `NGINX` proxy;
- Configure `Certbot` to get and prolong SSL certificates for our domain name;
- Configure `NGINX` to provide `HTTPS` connection and other tweaks;

As a result, the application is now available on [emur.space](https://emur.space/)