### PR TITLE
NT-28: Process lost connection

### DIFF
--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -78,6 +78,11 @@ function subscribe(gameId) {
         stompClient.subscribe("/lobby/" + gameId, payload => {
             processTopicMessage(JSON.parse(payload.body))
         });
+    }, function(message) {
+        if (message.startsWith("Whoops! Lost connection to")) {
+            renderAuthAndCreateConnectScreen()
+            showErrorMessage("You have been disconnected")
+        }
     });
     activeGameId = gameId
 }


### PR DESCRIPTION
📝 **NT-28** 

After client loses connection an error message is displayed and game returns to the first page
